### PR TITLE
Make mod compatible with BeamNG 0.35 update

### DIFF
--- a/scripts/rls_career_overhaul/modScript.lua
+++ b/scripts/rls_career_overhaul/modScript.lua
@@ -2,7 +2,7 @@ local function loadExtensions()
     print("Starting extension loading sequence")
     
     if extensions.isExtensionLoaded("core_recoveryPrompt") then
-        etExtensionUnloadMode("core_recoveryPrompt", "manual")
+        setExtensionUnloadMode("core_recoveryPrompt", "manual")
     end
     extensions.load("core_recoveryPrompt")
     setExtensionUnloadMode("core_recoveryPrompt", "manual")

--- a/scripts/rls_career_overhaul/modScript.lua
+++ b/scripts/rls_career_overhaul/modScript.lua
@@ -2,7 +2,7 @@ local function loadExtensions()
     print("Starting extension loading sequence")
     
     if extensions.isExtensionLoaded("core_recoveryPrompt") then
-        extensions.unload("core_recoveryPrompt")
+        etExtensionUnloadMode("core_recoveryPrompt", "manual")
     end
     extensions.load("core_recoveryPrompt")
     setExtensionUnloadMode("core_recoveryPrompt", "manual")


### PR DESCRIPTION
Update function call in modScript.lua . An issue with the previous version prevented the mod from loading on the latest version of BeamNG 0.35

Logs showed deprecated function call to extensions.unload . Replaced with suggested function setExtensionUnloadMode to maintain functionality. 

UI now loads, career mode loads into game and works